### PR TITLE
歯垢マネージャーの歯垢生成処理変更

### DIFF
--- a/ToothBrushGame/Classes/PlaqueManager.cpp
+++ b/ToothBrushGame/Classes/PlaqueManager.cpp
@@ -10,6 +10,9 @@
 //********************************************************************************
 #include "PlaqueManager.h"
 #include "Plaque.h"
+#include "Random.h"
+#include "ToothManager.h"
+#include "Gum.h"
 
 //================================================================================
 // コンストラクタ
@@ -79,7 +82,7 @@ PlaqueManager* PlaqueManager::create(int nPlaqueMaxNum,Layer* pLayer)
 {
     PlaqueManager* pPlaqueManager = new PlaqueManager();
 
-    pPlaqueManager->m_nPlaqueMaxNum = nPlaqueMaxNum;
+    pPlaqueManager->m_nPlaqueMaxNum = nPlaqueMaxNum = 1200;
     pPlaqueManager->m_pLayer = pLayer;
 
     pPlaqueManager->init();
@@ -94,16 +97,49 @@ void PlaqueManager::createPlaque(void)
 {
     Vec2 pos = Vec2(50,600);
 
+    std::set<int> randNum;
+
+    // グリッド数は(640/16)*(512/16)=40*32 =1280だが、端に行くのを防止するために一列ずつ減らして39*31=1209
+    getRandGlidNum(randNum, 0, 1209, m_nPlaqueMaxNum);
+    std::set<int>::iterator it = randNum.begin();
+
+    // 下歯茎の左上座標をスタート地点にする
+    Vec2 startVec = Vec2(0,320);
+
     // 生成チェック
     for(int nCnt = 0;nCnt < m_nPlaqueMaxNum;nCnt++)
     {
-        m_ppPlaque[nCnt] = Plaque::create(pos);
+        int nWork = (*it);
+        int nWorkX = nWork / 31;
+        int nWorkY = nWork - nWorkX * 31;
+        Vec2 workVec  = startVec;
+        workVec.x += nWorkX * 16 + 16;
+        workVec.y += nWorkY * 16 + 16;
+
+        m_ppPlaque[nCnt] = Plaque::create(workVec);
 
         m_pLayer->addChild(m_ppPlaque[nCnt]->getSprite());
 
         m_nPlaqueNum++;
 
-        pos.x += 10;
+        it++;
+    }
+}
+
+//================================================================================
+// 歯垢生成グリッド生成処理
+//================================================================================
+void PlaqueManager::getRandGlidNum(std::set<int>& result,int nMin,int nMax,int nNum)
+{
+    int randNum;
+
+    for(int nCnt = 0;nCnt < nNum;nCnt++)
+    {
+        do{
+            randNum = RandomMT::getRaodom(nMin, nMax);
+        }while (result.find(randNum) != result.end());
+
+        result.insert(randNum);
     }
 }
 

--- a/ToothBrushGame/Classes/PlaqueManager.h
+++ b/ToothBrushGame/Classes/PlaqueManager.h
@@ -55,6 +55,8 @@ private:
     Layer* m_pLayer;
 
     void createPlaque(void);
+
+    void getRandGlidNum(std::set<int>& result,int nMin,int nMax,int nNum);
 };
 
 #endif /* defined(__ToothBrushGame__PlaqueManager__) */


### PR DESCRIPTION
歯垢生成時ランダムでグリッドを算出し、生成。
今はマネージャーのクリエイトで適当に1200入れてあります
