### PR TITLE
シーン遷移時、タッチができなくなる現象の修正

### DIFF
--- a/ToothBrushGame/Classes/ResultScene.cpp
+++ b/ToothBrushGame/Classes/ResultScene.cpp
@@ -107,11 +107,12 @@ bool ResultScene::onTouchBegin(Touch* pTouch,Event* pEvent)
 {
     // タッチ座標の取得
     m_touchPos = pTouch->getLocation();
-    
-    Director::getInstance()->replaceScene(TransitionFade::create(1.0f,TitleScene::createScene(),Color3B::WHITE));
+
     this->getEventDispatcher()->removeAllEventListeners();
     this->removeAllChildren();
-    
+
+    Director::getInstance()->replaceScene(TransitionFade::create(1.0f,TitleScene::createScene(),Color3B::WHITE));
+
     return true;
 }
 

--- a/ToothBrushGame/Classes/TitleScene.cpp
+++ b/ToothBrushGame/Classes/TitleScene.cpp
@@ -105,10 +105,12 @@ bool TitleScene::onTouchBegin(Touch* pTouch,Event* pEvent)
 {
     // タッチ座標の取得
     m_touchPos = pTouch->getLocation();
-    
-    Director::getInstance()->replaceScene(TransitionFade::create(1.0f,GameMainScene::createScene(),Color3B::WHITE));
+
     this->getEventDispatcher()->removeAllEventListeners();
     this->removeAllChildren();
+    
+    Director::getInstance()->replaceScene(TransitionFade::create(1.0f,GameMainScene::createScene(),Color3B::WHITE));
+
     return true;
 }
 


### PR DESCRIPTION
新しいシーンをクリエイトした後イベントを消していたが、順番を逆にして
イベントを消した後新しいシーンを生成に
