### PR TITLE
メモリリークの修正

### DIFF
--- a/ToothBrushGame/Classes/AppDelegate.cpp
+++ b/ToothBrushGame/Classes/AppDelegate.cpp
@@ -35,8 +35,8 @@ bool AppDelegate::applicationDidFinishLaunching() {
     director->setAnimationInterval(1.0 / 60);
 
     // create a scene. it's an autorelease object
-    auto scene = GameMainScene::createScene();
-    
+    //auto scene = GameMainScene::createScene();
+        auto scene = TitleScene::createScene();
     // run
     director->runWithScene(scene);
 

--- a/ToothBrushGame/Classes/GameMainScene.cpp
+++ b/ToothBrushGame/Classes/GameMainScene.cpp
@@ -20,6 +20,52 @@
 #include "ResultScene.h"
 #include "TitleScene.h"
 USING_NS_CC;
+
+GameMainScene::~GameMainScene()
+{
+    if(m_pEnemyManager != nullptr)
+    {
+        delete m_pEnemyManager;
+        m_pEnemyManager = nullptr;
+    }
+
+    if(m_pToothManager != nullptr)
+    {
+        delete m_pToothManager;
+        m_pToothManager = nullptr;
+    }
+
+    if(m_pPlaqueManager != nullptr)
+    {
+        delete m_pPlaqueManager;
+        m_pPlaqueManager = nullptr;
+    }
+
+    if(m_pUIManager != nullptr)
+    {
+        delete m_pUIManager;
+        m_pUIManager = nullptr;
+    }
+
+    if(m_pBoss != nullptr)
+    {
+        delete m_pBoss;
+        m_pBoss = nullptr;
+    }
+
+    if(m_pHitChecker != nullptr)
+    {
+        delete m_pHitChecker;
+        m_pHitChecker = nullptr;
+    }
+
+    if(m_EffectManager != nullptr)
+    {
+        delete m_EffectManager;
+        m_EffectManager = nullptr;
+    }
+}
+
 //================================================================================
 // シーン生成
 //================================================================================
@@ -113,8 +159,6 @@ bool GameMainScene::init()
     m_oldTouchPos = m_touchPos;
     m_swipeDirection = SWIPE_DIRECTION_NONE;
     m_oldSwipeDirection = m_swipeDirection;
-    
-    this->addChild(Plaque::create(Vec2(64, 64))->getSprite());
     
     m_pHitChecker = HitChecker::create(m_pEnemyManager, m_pToothManager, m_pPlaqueManager);
     
@@ -213,6 +257,21 @@ void GameMainScene::update(float fTime)
 
     }
      */
+m_nTimer++;
+    if(m_nTimer != 0)
+    {
+
+        if(m_nTimer > 120)
+        {
+            this->getEventDispatcher()->removeAllEventListeners();
+            this->removeAllChildren();
+            Director::getInstance()->replaceScene(TransitionFade::create(1.0f,ResultScene::createScene(),Color3B::WHITE));
+
+            this->unscheduleUpdate();
+
+        }
+
+    }
 }
 
 //================================================================================

--- a/ToothBrushGame/Classes/GameMainScene.h
+++ b/ToothBrushGame/Classes/GameMainScene.h
@@ -25,7 +25,7 @@ class GameMainScene : public cocos2d::Layer
 {
 public:
     GameMainScene(){};
-    ~GameMainScene(){};
+    ~GameMainScene();
     // there's no 'id' in cpp, so we recommend returning the class instance pointer
     static cocos2d::Scene* createScene();
     

--- a/ToothBrushGame/Classes/ToothManager.cpp
+++ b/ToothBrushGame/Classes/ToothManager.cpp
@@ -20,8 +20,10 @@ static const int TOOTHMANAGER_DISPLAY_CENTER_X = (320);
 ToothManager::ToothManager(void)
 {
     // メンバ変数の初期化
+    m_pTopGum = nullptr;
     m_pTopTooth = nullptr;
     m_pBottomTooth = nullptr;
+    m_pBottomGum = nullptr;
     m_pLayer = nullptr;
 }
 
@@ -30,7 +32,29 @@ ToothManager::ToothManager(void)
 //================================================================================
 ToothManager::~ToothManager()
 {
+    if(m_pTopGum != nullptr)
+    {
+        delete m_pTopGum;
+        m_pTopGum = nullptr;
+    }
 
+    if(m_pTopTooth != nullptr)
+    {
+        delete m_pTopTooth;
+        m_pTopTooth = nullptr;
+    }
+
+    if(m_pBottomTooth != nullptr)
+    {
+        delete m_pBottomTooth;
+        m_pBottomTooth = nullptr;
+    }
+
+    if(m_pBottomGum != nullptr)
+    {
+        delete m_pBottomGum;
+        m_pBottomGum = nullptr;
+    }
 }
 
 //================================================================================

--- a/ToothBrushGame/Classes/UIManager.cpp
+++ b/ToothBrushGame/Classes/UIManager.cpp
@@ -35,7 +35,29 @@ UIManager::UIManager(void)
 //================================================================================
 UIManager::~UIManager()
 {
+    if(m_pScore != nullptr)
+    {
+        delete m_pScore;
+        m_pScore = nullptr;
+    }
 
+    if(m_pMenuBar != nullptr)
+    {
+        delete m_pMenuBar;
+        m_pMenuBar = nullptr;
+    }
+
+    if(m_pLifeBar != nullptr)
+    {
+        delete m_pLifeBar;
+        m_pLifeBar = nullptr;
+    }
+
+    if(m_pItem != nullptr)
+    {
+        delete  m_pItem;
+        m_pItem = nullptr;
+    }
 }
 
 //================================================================================


### PR DESCRIPTION
メモリリークの修正
歯マネージャーのデストラクタに開放処理を追加
UIマネージャーのデストラクタに開放処理を追加
GameMainのデストラクタを変更。開放処理を追加
以下メモリリークを確認するために変更
AppDelegateを最初のシーンをタイトルに
GameMainで時間が経つと遷移するように
GameMainで次のシーンを作成したさいupdateを停止// これは必要な処理かも？
