### PR TITLE
幼女表情切り替え処理の実装

### DIFF
--- a/ToothBrushGame/Classes/CharacterStatus.h
+++ b/ToothBrushGame/Classes/CharacterStatus.h
@@ -63,8 +63,11 @@ public:
 
     void setJump(float fTime = 0.5f,Vec2 move = Vec2(0,0),int nHigh = 60,int nCount = 1);
     void setPattern(CHARACTERSTATUS_PATTERN pattern);
-    CHARACTERSTATUS_PATTERN getPattern(void){return m_pattern;}
+    CHARACTERSTATUS_PATTERN getPattern(void);
     void checkChangePattern(int nEnemyAllNum,int nEnemyDownNum);
+
+    void setPatternChangeEnd(bool bFlg){m_bPatternChangeEnd = bFlg;}
+    void setAnimJumpInfinity(float fTime = 0.5f,Vec2 move = Vec2(0,0),int nHigh = 60);
 
 private:
     const char* IMAGE_LIST[CHARACTERSTATUS_PATTERN_MAX] =
@@ -83,6 +86,7 @@ private:
     Vec2 m_pos;
     Vec3 m_rot;
     bool m_bGiddy;
+    bool m_bPatternChangeEnd;
     CHARACTERSTATUS_PATTERN m_oldPattern;
     CHARACTERSTATUS_PATTERN m_pattern;
 };


### PR DESCRIPTION
敵の総数から割合を算出し、割合をこすたびに表情を切り替え。
切り替えはうがい処理をし、目眩状態になりその状態から復帰するときに切り替え判定。
表情が目眩になる前と後で違う際にジャンプするように設定。
また、クリア時に画像を切り替えるのはsetPatternにパターンGLADをよろしくです。
その際にsetPatternChangeEnd関数を呼んでtrueを入れると表情が固定されます。
setAnimJumpInfinityを呼ぶと自動的に繰り返しジャンプします。
