### PR TITLE
コンフィグ画面のたたき台作成

### DIFF
--- a/ToothBrushGame/Classes/ConfigScene.cpp
+++ b/ToothBrushGame/Classes/ConfigScene.cpp
@@ -1,0 +1,239 @@
+//********************************************************************************
+//  ConfigScene.cpp
+//  ToothBrushGame
+//
+//  Created by 丸山 潤 on 2014/10/27.
+//
+//********************************************************************************
+//********************************************************************************
+// インクルード
+//********************************************************************************
+#include "ConfigScene.h"
+#include "common.h"
+#include "TextureFile.h"
+
+//********************************************************************************
+// 静的メンバ変数宣言
+//********************************************************************************
+float ConfigScene::m_fShakePermissionDistance = 0.3f;
+
+//================================================================================
+// コンストラクタ
+//================================================================================
+ConfigScene::ConfigScene()
+{
+}
+
+//================================================================================
+// デストラクタ
+//================================================================================
+ConfigScene::~ConfigScene()
+{
+}
+
+//================================================================================
+// シーン生成
+//================================================================================
+Scene* ConfigScene::createScene()
+{
+    // 'scene' is an autorelease object
+    auto scene = Scene::create();
+
+    // 'layer' is an autorelease object
+    auto layer = ConfigScene::create();
+
+    // add layer as a child to scene
+    scene->addChild(layer);
+
+    // return the scene
+    return scene;
+}
+
+//================================================================================
+// 初期化処理
+//================================================================================
+bool ConfigScene::init(void)
+{
+    if( !Layer::init() )
+    {
+        return false;
+    }
+
+    Size visibleSize = Director::getInstance()->getVisibleSize() / 2 + SCREEN_CENTER;
+    Vec2 origin = Director::getInstance()->getVisibleSize() / 2 - SCREEN_CENTER;
+
+    //終了ボタン生成
+    auto closeItem = MenuItemImage::create(
+                                           "CloseNormal.png",
+                                           "CloseSelected.png",
+                                           CC_CALLBACK_1(ConfigScene::menuCloseCallback, this));
+
+    closeItem->setPosition(Vec2(origin.x + visibleSize.width - closeItem->getContentSize().width/2 ,
+                                origin.y + closeItem->getContentSize().height/2));
+
+    // create menu, it's an autorelease object
+    auto menu = Menu::create(closeItem, NULL);
+    menu->setPosition(Vec2::ZERO);
+    this->addChild(menu, 1);
+
+    // 更新処理の追加
+    this->scheduleUpdate();
+
+    // タッチ機能の有効化
+    m_pTouchEventOneByOne =  EventListenerTouchOneByOne::create();
+    m_pTouchEventOneByOne->setSwallowTouches(true);
+    m_pTouchEventOneByOne->onTouchBegan = CC_CALLBACK_2(ConfigScene::onTouchBegin,this);
+    m_pTouchEventOneByOne->onTouchMoved = CC_CALLBACK_2(ConfigScene::onTouchMoved,this);
+    m_pTouchEventOneByOne->onTouchCancelled = CC_CALLBACK_2(ConfigScene::onTouchCancelled, this);
+    m_pTouchEventOneByOne->onTouchEnded = CC_CALLBACK_2(ConfigScene::onTouchEnded, this);
+    this->getEventDispatcher()->addEventListenerWithFixedPriority(m_pTouchEventOneByOne, 1);
+
+    // シェイク感度のラベル生成
+    m_pShakeStatementLabel = Label::createWithSystemFont("シェイクの感度 低1~10高", "ariel", 16);
+    m_pShakeStatementLabel->setColor(Color3B::WHITE);
+    m_pShakeStatementLabel->enableOutline(Color4B::BLACK,5);
+    m_pShakeStatementLabel->setPosition(visibleSize.width / 2,visibleSize.height / 2);
+    this->addChild(m_pShakeStatementLabel);
+
+    // シェイク感度数値のラベル生成
+    auto pNumString = StringUtils::format("%.2f", this->m_fShakePermissionDistance);
+    m_pShakeNumLabel = Label::createWithSystemFont(pNumString.c_str(), "ariel", 16);
+    m_pShakeNumLabel->setColor(Color3B::WHITE);
+    m_pShakeNumLabel->enableOutline(Color4B::BLACK,5);
+    m_pShakeNumLabel->setPosition(visibleSize.width / 2,visibleSize.height / 2 - 100);
+    this->addChild(m_pShakeNumLabel);
+
+    // シェイク感度上昇矢印の生成
+    Vec2 workPos = visibleSize / 2;
+    m_pShakeUpArrowImage = MenuItemImage::create(TEX_PLAQUE_WAIT_01,TEX_PLAQUE_WAIT_01,
+                                                 CC_CALLBACK_0(ConfigScene::shakeUpArrowCallback,this));
+    m_pShakeUpArrowImage->setPosition(visibleSize.width / 2 + 100,visibleSize.height / 2 - 100);
+
+    // シェイク感度低下矢印の生成
+    Rect arrowImageRect = m_pShakeUpArrowImage->getBoundingBox();
+    workPos += arrowImageRect.size / 2;
+    m_pShakeDownArrowImage = MenuItemImage::create(TEX_PLAQUE_WAIT_01,TEX_PLAQUE_WAIT_01,
+                                                   CC_CALLBACK_0(ConfigScene::shakeDownArrowCallback,this));
+    m_pShakeDownArrowImage->setPosition(visibleSize.width / 2 - 100,visibleSize.height / 2 - 100);
+
+    // シェイク感度変更矢印のメニュー登録
+    Menu* pShakeArrowMenu = Menu::create(m_pShakeUpArrowImage,m_pShakeDownArrowImage, NULL);
+    pShakeArrowMenu->setPosition(Vec2::ZERO);
+    this->addChild(pShakeArrowMenu);
+
+    // コンフィグ終了ボタンの生成
+    m_pConfigCloseImage = MenuItemImage::create("ButtonReturnGame.png","ButtonReturnGame.png",
+                                                CC_CALLBACK_0(ConfigScene::configCloseCallback, this));
+    m_pConfigCloseImage->setPosition(Vec2(visibleSize.width / 2,origin.y));
+
+    // コンフィグ終了メニュー登録
+    Menu* pConfigCloseMenu = Menu::create(m_pConfigCloseImage,NULL);
+    pConfigCloseMenu->setPosition(Vec2::ZERO);
+    this->addChild(pConfigCloseMenu);
+
+    return true;
+}
+
+//================================================================================
+// 更新処理
+//================================================================================
+void ConfigScene::update(float fTime)
+{
+}
+
+//================================================================================
+// ゲーム終了処理
+//================================================================================
+void ConfigScene::menuCloseCallback(Ref* pSender)
+{
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WP8) || (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
+    MessageBox("You pressed the close button. Windows Store Apps do not implement a close button.","Alert");
+    return;
+#endif
+
+    Director::getInstance()->end();
+
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_IOS)
+    exit(0);
+#endif
+}
+
+//================================================================================
+// タップ開始判定
+//================================================================================
+bool ConfigScene::onTouchBegin(Touch* pTouch,Event* pEvent)
+{
+    // タッチ座標の取得
+    m_touchPos = pTouch->getLocation();
+
+    return true;
+}
+
+//================================================================================
+// スワイプ判定
+//================================================================================
+void ConfigScene::onTouchMoved(Touch* pTouch,Event* pEvent)
+{
+    // タッチ座標の取得
+    m_oldTouchPos = m_touchPos;
+    m_touchPos = pTouch->getLocation();
+}
+
+//================================================================================
+// タップ離した判定
+//================================================================================
+void ConfigScene::onTouchEnded(Touch* pTouch, Event* pEvent)
+{
+
+}
+
+//================================================================================
+// タッチ時に割り込み処理
+//================================================================================
+void ConfigScene::onTouchCancelled(Touch* pTouch, Event* pEvent)
+{
+    
+}
+
+//================================================================================
+// シェイク感度上昇コールバック
+//================================================================================
+void ConfigScene::shakeUpArrowCallback(void)
+{
+    m_fShakePermissionDistance += 0.1f;
+    shakeNumlabelRefresh();
+}
+
+//================================================================================
+// シェイク感度低下コールバック
+//================================================================================
+void ConfigScene::shakeDownArrowCallback(void)
+{
+    if(m_fShakePermissionDistance <= 0.1f)
+    {
+        return;
+    }
+    m_fShakePermissionDistance -= 0.1f;
+    shakeNumlabelRefresh();
+}
+
+//================================================================================
+// シェイク数値ラベルリフレッシュ処理
+//================================================================================
+void ConfigScene::shakeNumlabelRefresh(void)
+{
+    auto pNumString = StringUtils::format("%.2f", this->m_fShakePermissionDistance);
+    m_pShakeNumLabel->setString(pNumString.c_str());
+}
+
+//================================================================================
+// コンフィグ終了コールバック
+//================================================================================
+void ConfigScene::configCloseCallback(void)
+{
+    this->getEventDispatcher()->removeEventListener(m_pTouchEventOneByOne);
+    this->removeAllChildren();
+    this->unscheduleUpdate();
+    
+    Director::getInstance()->popScene();
+}

--- a/ToothBrushGame/Classes/ConfigScene.h
+++ b/ToothBrushGame/Classes/ConfigScene.h
@@ -1,0 +1,74 @@
+//********************************************************************************
+//  ConfigScene.h
+//  ToothBrushGame
+//
+//  Created by 丸山 潤 on 2014/10/27.
+//
+//********************************************************************************
+//********************************************************************************
+// インクルードガード
+//********************************************************************************
+#ifndef __ToothBrushGame__ConfigScene__
+#define __ToothBrushGame__ConfigScene__
+
+//********************************************************************************
+// インクルード
+//********************************************************************************
+#include "cocos2d.h"
+
+//********************************************************************************
+// 名前空間の使用
+//********************************************************************************
+using namespace cocos2d;
+
+//********************************************************************************
+// クラス宣言
+//********************************************************************************
+class ConfigScene : public cocos2d::Layer
+{
+public:
+    ConfigScene();
+    ~ConfigScene();
+    // there's no 'id' in cpp, so we recommend returning the class instance pointer
+    static cocos2d::Scene* createScene();
+
+    // Here's a difference. Method 'init' in cocos2d-x returns bool, instead of returning 'id' in cocos2d-iphone
+    virtual bool init();
+
+    void update(float fTime);
+
+    // a selector callback
+    void menuCloseCallback(cocos2d::Ref* pSender);
+
+    // implement the "static create()" method manually
+    CREATE_FUNC(ConfigScene);
+
+    static float getShakePermissionDistance(void){return m_fShakePermissionDistance;}
+
+private:
+    bool onTouchBegin(Touch* pTouch,Event* pEvent);
+    void onTouchMoved(Touch* pTouch,Event* pEvent);
+    void onTouchCancelled(Touch* pTouch,Event* pEvent);
+    void onTouchEnded(Touch* pTouch,Event* pEvent);
+
+    void shakeUpArrowCallback(void);
+    void shakeDownArrowCallback(void);
+    void configCloseCallback(void);
+
+    void shakeNumlabelRefresh(void);
+
+    Point m_touchPos;
+    Point m_oldTouchPos;
+    EventListenerTouchOneByOne* m_pTouchEventOneByOne;
+
+    MenuItemImage* m_pConfigCloseImage;
+
+    MenuItemImage* m_pShakeUpArrowImage;
+    MenuItemImage* m_pShakeDownArrowImage;
+    Label* m_pShakeStatementLabel;
+    Label* m_pShakeNumLabel;
+
+    static float m_fShakePermissionDistance;
+};
+
+#endif /* defined(__ToothBrushGame__ConfigScene__) */

--- a/ToothBrushGame/Classes/GameMainScene.cpp
+++ b/ToothBrushGame/Classes/GameMainScene.cpp
@@ -30,8 +30,8 @@
 #include "VirusToothManager.h"
 #include "VirusTooth.h"
 #include "Clock.h"
+#include "ConfigScene.h"
 USING_NS_CC;
-#define SHAKE_PERMISSION_DISTANCE (0.3f)
 
 static const GAME_PASE_DATA GamePhaseData[PHASE_MAX] =
 {
@@ -416,7 +416,7 @@ void GameMainScene::onAcceleration(Acceleration *acc,Event *unused_event)
     Vec3 work = m_acc - m_oldAcc;
     float fDistance = (work.x * work.x + work.y * work.y + work.z * work.z);
 
-    if(fDistance > SHAKE_PERMISSION_DISTANCE)
+    if(fDistance > ConfigScene::getShakePermissionDistance())
     {
         m_nShakeCnt++;
     }

--- a/ToothBrushGame/Classes/PauseScene.cpp
+++ b/ToothBrushGame/Classes/PauseScene.cpp
@@ -10,6 +10,7 @@
 #include "GameMainScene.h"
 #include "TitleScene.h"
 #include "Sound.h"
+#include "ConfigScene.h"
 
 USING_NS_CC;
 //================================================================================
@@ -17,7 +18,7 @@ USING_NS_CC;
 //================================================================================
 PauseScene::~PauseScene()
 {
-    //this->getEventDispatcher()->removeEventListener(m_pTouchEventOneByOne);
+    m_bConfig = false;
 }
 
 //================================================================================
@@ -68,7 +69,7 @@ bool PauseScene::init()
     m_pTouchEventOneByOne->onTouchMoved = CC_CALLBACK_2(PauseScene::onTouchMoved,this);
     m_pTouchEventOneByOne->onTouchCancelled = CC_CALLBACK_2(PauseScene::onTouchCancelled, this);
     m_pTouchEventOneByOne->onTouchEnded = CC_CALLBACK_2(PauseScene::onTouchEnded, this);
-    this->getEventDispatcher()->addEventListenerWithFixedPriority(m_pTouchEventOneByOne, 1);
+    this->getEventDispatcher()->addEventListenerWithFixedPriority(m_pTouchEventOneByOne, 2);
 
     // 薄暗いスプライトを作成
     m_pMaskSprite = Sprite::create();
@@ -96,6 +97,12 @@ bool PauseScene::init()
     m_pReturnGameSprite->setPosition(Vec2(400,800));
     this->addChild(m_pReturnGameSprite);
 
+    m_pConfigSprite = Sprite::create();
+    m_pConfigSprite->setTextureRect(Rect(0,0,100,100));
+    m_pConfigSprite->setColor(Color3B::YELLOW);
+    m_pConfigSprite->setPosition(Vec2(400,200));
+    this->addChild(m_pConfigSprite);
+
     return true;
 }
 
@@ -121,7 +128,13 @@ void PauseScene::menuCloseCallback(Ref* pSender)
 //================================================================================
 void PauseScene::update(float fTime)
 {
-
+    // コンフィグから戻ってきていたら
+    if(m_bConfig)
+    {
+        // 親レイヤーの更新を止める
+        Layer* pParent = static_cast<Layer*>(this->getParent());
+        pParent->pause();
+    }
 }
 
 //================================================================================
@@ -169,6 +182,12 @@ bool PauseScene::onTouchBegin(Touch* pTouch,Event* pEvent)
         return true;
     }
 
+    Rect openConfigSpriteRect = m_pConfigSprite->getBoundingBox();
+    if(openConfigSpriteRect.containsPoint(m_touchPos))
+    {
+        openConfig();
+    }
+
     return true;
 }
 
@@ -177,11 +196,8 @@ bool PauseScene::onTouchBegin(Touch* pTouch,Event* pEvent)
 //================================================================================
 void PauseScene::onTouchMoved(Touch* pTouch,Event* pEvent)
 {
-
     // タッチ座標の取得
     m_touchPos = pTouch->getLocation();
-
-
 }
 
 //================================================================================
@@ -236,4 +252,13 @@ void PauseScene::returnTitle(void)
     this->unscheduleUpdate();
 
     Director::getInstance()->replaceScene(TransitionFade::create(1.0f,TitleScene::createScene(),Color3B::WHITE));
+}
+
+//================================================================================
+// コンフィグオープン処理
+//================================================================================
+void PauseScene::openConfig(void)
+{
+    m_bConfig = true;
+    Director::getInstance()->pushScene(ConfigScene::createScene());
 }

--- a/ToothBrushGame/Classes/PauseScene.h
+++ b/ToothBrushGame/Classes/PauseScene.h
@@ -35,15 +35,18 @@ public:
 private:
     Point m_touchPos;
     EventListenerTouchOneByOne* m_pTouchEventOneByOne;
+    bool m_bConfig;
 
     void returnGame(void);
     void retryGame(void);
     void returnTitle(void);
+    void openConfig(void);
 
     Sprite* m_pMaskSprite;
     Sprite* m_pRetryGameSprite;
     Sprite* m_pReturnGameSprite;
     Sprite* m_pReturnTitleSprite;
+    Sprite* m_pConfigSprite;
 
     bool onTouchBegin(Touch* pTouch,Event* pEvent);
     void onTouchMoved(Touch* pTouch,Event* pEvent);


### PR DESCRIPTION
コンフィグシーン
コンフィグ画面のたたき台作成。
スワイプ感度のみ実装。レイアウトは適当。
ポーズシーン
コンフィグに移行する処理を追加
アップデートにコンフィグからかえってきた際の処理を追加。
ゲームメイン
コンフィグヘッダーをインクルード。
スワイプ許可距離defineの削除
シェイクの判定時、今まで距離をdefineで定義していたものから、コンフィグからゲットしたものに変更
