### PR TITLE
ポーズの処理変更&メモリリーク一部解消

### DIFF
--- a/ToothBrushGame/Classes/PauseScene.h
+++ b/ToothBrushGame/Classes/PauseScene.h
@@ -37,15 +37,17 @@ private:
     EventListenerTouchOneByOne* m_pTouchEventOneByOne;
     bool m_bConfig;
 
-    void returnGame(void);
-    void retryGame(void);
-    void returnTitle(void);
     void openConfig(void);
 
+    void returnGameCallback(void);
+    void retryGameCallback(void);
+    void returnTitleCallback(void);
+
     Sprite* m_pMaskSprite;
-    Sprite* m_pRetryGameSprite;
-    Sprite* m_pReturnGameSprite;
-    Sprite* m_pReturnTitleSprite;
+    Sprite* m_pMenuBarSpriteBase;
+    Sprite* m_pRetryGameSpriteBase;
+    Sprite* m_pReturnGameSpriteBase;
+    Sprite* m_pReturnTitleSpriteBase;
     Sprite* m_pConfigSprite;
 
     bool onTouchBegin(Touch* pTouch,Event* pEvent);

--- a/ToothBrushGame/Classes/UIManager.cpp
+++ b/ToothBrushGame/Classes/UIManager.cpp
@@ -46,7 +46,7 @@ UIManager::~UIManager()
     //SAFE_DELETE(m_pLifeBar);
     SAFE_DELETE(m_pToothPowder);
     SAFE_DELETE(m_pCharacterStatus);
-
+    SAFE_DELETE(m_pClock);
 }
 
 //================================================================================


### PR DESCRIPTION
ポーズのボタン処理をコールバックに変更
ポーズにメニューバーを設置。押すことでゲームに戻る
コンフィグのボタンについては手を付けてない

UIマネージャーにクロックのSAFE_DELETEが抜けていたため、追加
